### PR TITLE
Fix export for commonjs

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -1,3 +1,3 @@
 const { WebSocket } = require('ws')
 
-export { WebSocket }
+module.exports = WebSocket;


### PR DESCRIPTION
Currently, commonjs projects will be hit with the following:
```
/.../node_modules/unws/src/node.js:3
export { WebSocket }
^^^^^^

SyntaxError: Unexpected token 'export'
```

I am quite positive that this PR should solve that issue. I tested this on Node `v16.16.0` & `v18.14.2` with a `commonjs` and a `module` project and lastly with a nodejs (index.js) script and a typescript (index.ts) script via `ts-node`. All combinations of what I mentioned here.